### PR TITLE
Add admin filters for quiz results

### DIFF
--- a/ui/src/styles/user-dashboard.css
+++ b/ui/src/styles/user-dashboard.css
@@ -93,6 +93,20 @@
   color: var(--primary-color);
 }
 
+.admin-filters {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.admin-filters .filter-input,
+.admin-filters .filter-select {
+  padding: 0.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+}
+
 .quiz-result-item {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- improve admin dashboard with user/quiz filtering
- style new filters in the dashboard CSS

## Testing
- `npm run lint`
- `npm run build`
- `mvn -q -DskipTests package` *(fails: Could not download Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687bed223f04832e8234b037b0b75b70