### PR TITLE
Improve quiz UI features

### DIFF
--- a/ui/src/components/quiz/QuizPanel.jsx
+++ b/ui/src/components/quiz/QuizPanel.jsx
@@ -118,9 +118,11 @@ export const QuizPanel = () => {
                 <DataView className="quiz-list" value={quizzes} itemTemplate={itemTemplate} />
               </CustomCard>
 
-              <CustomCard title="Detalles del Quiz" className="quiz-detail-card">
-                <QuizDetail quiz={selectedQuiz} onEdit={handleEditQuiz} user={user} />
-              </CustomCard>
+              {selectedQuiz && (
+                <CustomCard title="Detalles del Quiz" className="quiz-detail-card">
+                  <QuizDetail quiz={selectedQuiz} onEdit={handleEditQuiz} user={user} />
+                </CustomCard>
+              )}
             </div>
 
             <QuizModal

--- a/ui/src/components/ui/ProcessingOverlay.jsx
+++ b/ui/src/components/ui/ProcessingOverlay.jsx
@@ -1,13 +1,31 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import logo from '../../assets/shark-ia.png';
 import '../../styles/processing-overlay.css';
 
 export const ProcessingOverlay = ({ visible, message = 'Procesando...' }) => {
+  const [elapsed, setElapsed] = useState(0);
+
+  useEffect(() => {
+    let interval;
+    if (visible) {
+      interval = setInterval(() => setElapsed((e) => e + 1), 1000);
+    } else {
+      setElapsed(0);
+    }
+    return () => clearInterval(interval);
+  }, [visible]);
+
+  const formatTime = (sec) => {
+    const m = Math.floor(sec / 60).toString().padStart(2, '0');
+    const s = (sec % 60).toString().padStart(2, '0');
+    return `${m}:${s}`;
+  };
+
   if (!visible) return null;
   return (
     <div className="processing-overlay">
       <img src={logo} alt="SharkAI" className="processing-logo" />
-      <span className="processing-message">{message}</span>
+      <span className="processing-message">{`${message} ${formatTime(elapsed)}`}</span>
     </div>
   );
 };

--- a/ui/src/pages/QuizTaker.jsx
+++ b/ui/src/pages/QuizTaker.jsx
@@ -161,7 +161,13 @@ const QuizTaker = () => {
   };
 
   const handleExportPdf = () => {
-    window.print();
+    const newWindow = window.open('', '', 'width=800,height=600');
+    if (!newWindow) return;
+    newWindow.document.write(`<html><head><title>Resultado Quiz</title></head><body><pre style="white-space: pre-wrap; font-family: inherit;">${llmResponse}</pre></body></html>`);
+    newWindow.document.close();
+    newWindow.focus();
+    newWindow.print();
+    newWindow.close();
   };
 
   const handleGoBack = () => {


### PR DESCRIPTION
## Summary
- hide details panel when no quiz is selected
- add timer to processing overlay
- export LLM result to a PDF-friendly window instead of the whole page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a94e0b46c832eb5d454052714946f