### PR TITLE
Update quiz results modal

### DIFF
--- a/ui/src/pages/QuizTaker.jsx
+++ b/ui/src/pages/QuizTaker.jsx
@@ -311,12 +311,6 @@ const QuizTaker = () => {
                     severity="secondary"
                     onClick={handleExportPdf}
                 />
-                <CustomButton
-                    label="Grabar"
-                    icon="pi pi-save"
-                    severity="success"
-                    onClick={handleCloseModal}
-                />
               </div>
             }
             style={{ width: '60vw', minWidth: 400, maxWidth: 800 }}


### PR DESCRIPTION
## Summary
- remove the extra action button from the quiz results modal

## Testing
- `npm run lint`
- `npm run build`
- `mvn -q -DskipTests package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688a97b09ac0832e970aae811ffd4a9d