### PR TITLE
Add quiz ID field and tooltip

### DIFF
--- a/ui/src/components/quiz/QuizDetail.jsx
+++ b/ui/src/components/quiz/QuizDetail.jsx
@@ -22,6 +22,7 @@ export const QuizDetail = ({ quiz, onEdit }) => {
         <div className="quiz-detail-container">
             <div className="quiz-detail-header">
                 <h3>{quiz.tema}</h3>
+                <p className="quiz-id-label" title={quiz.tema}><strong>Id:</strong> {quiz.documentId}</p>
                 <div className="quiz-detail-actions">
                     <CustomButton
                         label="Editar"

--- a/ui/src/components/ui/QuizModal.jsx
+++ b/ui/src/components/ui/QuizModal.jsx
@@ -6,6 +6,7 @@ import { useState, useEffect } from "react";
 export const QuizModal = ({ visible, onHide, onSave, editMode = false, initialData = null }) => {
     const [quizTitle, setQuizTitle] = useState("");
     const [quizPrompt, setQuizPrompt] = useState("");
+    const [quizId, setQuizId] = useState("");
     const [defaultPrompt, setDefaultPrompt] = useState("");
     const [questions, setQuestions] = useState([{ id: 1, value: "", options: [""], random: false }]);
     const MAX_QUESTIONS = 5;
@@ -30,6 +31,7 @@ export const QuizModal = ({ visible, onHide, onSave, editMode = false, initialDa
         if (editMode && initialData) {
             setQuizTitle(initialData.tema || "");
             setQuizPrompt(initialData.prompt || "");
+            setQuizId(initialData.documentId || "");
             
             if (initialData.steps && initialData.steps.length > 0) {
                 const formattedQuestions = initialData.steps.map((step, index) => ({
@@ -44,6 +46,7 @@ export const QuizModal = ({ visible, onHide, onSave, editMode = false, initialDa
             // Reset form for create mode
             setQuizTitle("");
             setQuizPrompt("");
+            setQuizId("");
             setQuestions([{ id: 1, value: "", options: [""], random: false }]);
         }
     }, [editMode, initialData, visible]);
@@ -117,6 +120,7 @@ export const QuizModal = ({ visible, onHide, onSave, editMode = false, initialDa
             // Only reset form when creating new quiz
             setQuizTitle("");
             setQuizPrompt("");
+            setQuizId("");
             setQuestions([{ id: 1, value: "", options: [""], random: false }]);
         }
         onHide();
@@ -137,9 +141,9 @@ export const QuizModal = ({ visible, onHide, onSave, editMode = false, initialDa
                 }))
         };
         
-        if (editMode && initialData) {
+        if (editMode) {
             // Include documentId for editing
-            quizData.documentId = initialData.documentId;
+            quizData.documentId = quizId;
         }
         
         onSave(quizData);
@@ -157,6 +161,23 @@ export const QuizModal = ({ visible, onHide, onSave, editMode = false, initialDa
             style={{ width: '50vw', minWidth: '400px', height: '700px' }}
         >
             <div className="quiz-content">
+                {/* Quiz Id (documentId) */}
+                {editMode && (
+                    <div className="quiz-id-section">
+                        <label htmlFor="quiz-id" className="quiz-id-label">
+                            <i className="pi pi-id-card" style={{ marginRight: '0.5rem' }}></i>
+                            Id
+                        </label>
+                        <InputField
+                            id="quiz-id"
+                            value={quizId}
+                            onChange={(e) => setQuizId(e.target.value)}
+                            placeholder="Id del quiz"
+                            className="quiz-id-input"
+                        />
+                    </div>
+                )}
+
                 {/* Título del Quiz */}
                 <div className="quiz-title-section">
                     <label htmlFor="quiz-title" className="quiz-title-label">

--- a/ui/src/styles/quiz.css
+++ b/ui/src/styles/quiz.css
@@ -100,6 +100,17 @@
     color: var(--text-on-primary);
 }
 
+/* Estilos para el id del quiz en el modal */
+.quiz-id-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 1.25rem;
+    background: var(--primary-color);
+    border-radius: 12px;
+    color: var(--text-on-primary);
+}
+
 .modal-footer .p-button-primary {
     background-color: var(--primary-color);
     color: var(--text-on-primary);
@@ -191,11 +202,30 @@
     font-weight: 500;
 }
 
+.quiz-id-input.p-inputtext {
+    width: 100%;
+    padding: 0.75rem;
+    border-radius: 8px;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    font-size: 1.1rem;
+    font-weight: 500;
+}
+
 .quiz-title-input .p-inputtext::placeholder {
     color: rgba(255, 255, 255, 0.7);
 }
 
+.quiz-id-input .p-inputtext::placeholder {
+    color: rgba(255, 255, 255, 0.7);
+}
+
 .quiz-title-input .p-inputtext:focus {
+    border-color: rgba(255, 255, 255, 0.8);
+    box-shadow: 0 0 0 0.2rem rgba(255, 255, 255, 0.25);
+    background-color: rgba(255, 255, 255, 0.15);
+}
+
+.quiz-id-input .p-inputtext:focus {
     border-color: rgba(255, 255, 255, 0.8);
     box-shadow: 0 0 0 0.2rem rgba(255, 255, 255, 0.25);
     background-color: rgba(255, 255, 255, 0.15);


### PR DESCRIPTION
## Summary
- show `Id` with tooltip in quiz details
- allow editing quiz ID in modal
- tweak styles for new `Id` field

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a9bbb9640832eafbed670de66ac6c