### PR TITLE
Add accenture-only registration with email confirmation

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -51,6 +51,12 @@
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
 
+        <!-- Mail -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+
         <!-- PostgreSQL -->
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/backend/src/main/java/org/shark/alma/adapter/in/rest/UserController.java
+++ b/backend/src/main/java/org/shark/alma/adapter/in/rest/UserController.java
@@ -1,10 +1,13 @@
 package org.shark.alma.adapter.in.rest;
 
 import org.shark.alma.application.service.UserService;
+import org.shark.alma.application.service.RegistrationService;
 import org.shark.alma.domain.model.user.LoginRequest;
 import org.shark.alma.domain.model.user.LoginResponse;
 import org.shark.alma.domain.model.user.User;
 import org.shark.alma.domain.model.user.UserDto;
+import org.shark.alma.domain.model.user.RegistrationRequest;
+import org.shark.alma.domain.model.user.GenericResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -22,6 +25,9 @@ public class UserController {
 
     @Autowired
     private UserService userService;
+
+    @Autowired
+    private RegistrationService registrationService;
 
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest loginRequest) {
@@ -59,6 +65,26 @@ public class UserController {
         } else {
             logger.warn("Usuario no encontrado: {}", email);
             return ResponseEntity.notFound().build();
+        }
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<GenericResponse> register(@RequestBody RegistrationRequest request) {
+        try {
+            registrationService.register(request.getEmail(), request.getPassword());
+            return ResponseEntity.ok(new GenericResponse(true, "Registro iniciado. Revisa tu correo."));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(new GenericResponse(false, e.getMessage()));
+        }
+    }
+
+    @GetMapping("/confirm")
+    public ResponseEntity<GenericResponse> confirm(@RequestParam String token) {
+        boolean ok = registrationService.confirm(token);
+        if (ok) {
+            return ResponseEntity.ok(new GenericResponse(true, "Usuario confirmado"));
+        } else {
+            return ResponseEntity.badRequest().body(new GenericResponse(false, "Token inválido"));
         }
     }
 }

--- a/backend/src/main/java/org/shark/alma/application/service/EmailService.java
+++ b/backend/src/main/java/org/shark/alma/application/service/EmailService.java
@@ -1,0 +1,25 @@
+package org.shark.alma.application.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailService {
+
+    @Autowired
+    private JavaMailSender mailSender;
+
+    @Value("${app.confirm-url:http://localhost:8082/api/auth/confirm?token=}")
+    private String confirmUrl;
+
+    public void sendConfirmationEmail(String to, String token) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject("Confirmación de cuenta");
+        message.setText("Para confirmar tu cuenta haz clic en el siguiente enlace: " + confirmUrl + token);
+        mailSender.send(message);
+    }
+}

--- a/backend/src/main/java/org/shark/alma/application/service/RegistrationService.java
+++ b/backend/src/main/java/org/shark/alma/application/service/RegistrationService.java
@@ -1,0 +1,45 @@
+package org.shark.alma.application.service;
+
+import org.shark.alma.domain.model.user.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class RegistrationService {
+
+    private final Map<String, User> pendingUsers = new ConcurrentHashMap<>();
+
+    @Autowired
+    private EmailService emailService;
+
+    @Autowired
+    private UserService userService;
+
+    public String register(String email, String password) {
+        if (!email.toLowerCase().endsWith("@accenture.com")) {
+            throw new IllegalArgumentException("Solo se permiten emails de accenture.com");
+        }
+        String token = UUID.randomUUID().toString();
+        User user = User.builder()
+                .email(email.trim())
+                .password(password.trim())
+                .administrador(false)
+                .build();
+        pendingUsers.put(token, user);
+        emailService.sendConfirmationEmail(email, token);
+        return token;
+    }
+
+    public boolean confirm(String token) {
+        User user = pendingUsers.remove(token);
+        if (user == null) {
+            return false;
+        }
+        userService.saveUser(user);
+        return true;
+    }
+}

--- a/backend/src/main/java/org/shark/alma/domain/model/user/GenericResponse.java
+++ b/backend/src/main/java/org/shark/alma/domain/model/user/GenericResponse.java
@@ -1,0 +1,11 @@
+package org.shark.alma.domain.model.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class GenericResponse {
+    private boolean success;
+    private String message;
+}

--- a/backend/src/main/java/org/shark/alma/domain/model/user/RegistrationRequest.java
+++ b/backend/src/main/java/org/shark/alma/domain/model/user/RegistrationRequest.java
@@ -1,0 +1,9 @@
+package org.shark.alma.domain.model.user;
+
+import lombok.Data;
+
+@Data
+public class RegistrationRequest {
+    private String email;
+    private String password;
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -22,6 +22,14 @@ spring:
       schema-locations: classpath:schema.sql
       data-locations: classpath:data.sql
       continue-on-error: true
+  mail:
+    host: localhost
+    port: 1025
+    username: ""
+    password: ""
+
+app:
+  confirm-url: http://localhost:8082/api/auth/confirm?token=
 
 
 llm:

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-d
 import { AuthProvider } from './contexts/AuthContext';
 import { ProtectedRoute } from './components/auth/ProtectedRoute';
 import Login from './pages/Login';
+import Register from './pages/Register';
 import Home from './pages/Home';
 import QuizTaker from './pages/QuizTaker';
 import UserDashboard from './pages/UserDashboard';
@@ -20,6 +21,7 @@ function App() {
         <div className="App">
           <Routes>
             <Route path="/login" element={<Login />} />
+            <Route path="/register" element={<Register />} />
             <Route 
               path="/home" 
               element={

--- a/ui/src/config/auth.js
+++ b/ui/src/config/auth.js
@@ -8,6 +8,7 @@ export const AUTH_CONFIG = {
 
 export const API_ENDPOINTS = {
   LOGIN: '/auth/login',
+  REGISTER: '/auth/register',
   LOGOUT: '/auth/logout',
   REFRESH: '/auth/refresh',
   PROFILE: '/auth/profile',

--- a/ui/src/config/routes.js
+++ b/ui/src/config/routes.js
@@ -1,13 +1,15 @@
 
 export const ROUTES = {
   LOGIN: '/login',
+  REGISTER: '/register',
   HOME: '/home',
   DASHBOARD: '/dashboard',
   PROFILE: '/profile'
 };
 
 export const PUBLIC_ROUTES = [
-  ROUTES.LOGIN
+  ROUTES.LOGIN,
+  ROUTES.REGISTER
 ];
 
 export const PROTECTED_ROUTES = [

--- a/ui/src/pages/Login.jsx
+++ b/ui/src/pages/Login.jsx
@@ -118,6 +118,9 @@ const Login = () => {
             <a href="#" className="forgot-password">
               ¿Olvidaste tu contraseña?
             </a>
+            <a href="/register" className="forgot-password">
+              Crear cuenta
+            </a>
           </div>
 
           {!showRoleButtons && (

--- a/ui/src/pages/Register.jsx
+++ b/ui/src/pages/Register.jsx
@@ -1,0 +1,62 @@
+import '../styles/login-form.css';
+import { useState, useRef } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { Toast } from 'primereact/toast';
+import { CustomCard } from '../components/ui/CustomCard';
+import { CustomButton } from '../components/ui/CustomButton';
+import { InputField } from '../components/ui/InputField';
+
+const Register = () => {
+  const [form, setForm] = useState({ email: '', password: '' });
+  const toast = useRef(null);
+  const navigate = useNavigate();
+
+  const handleChange = (field, value) => {
+    setForm(prev => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const baseUrl = import.meta.env.VITE_API_URL || '/api';
+    const res = await fetch(`${baseUrl}/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form)
+    });
+    const data = await res.json();
+    if (data.success) {
+      toast.current.show({ severity: 'success', summary: 'Registro', detail: data.message });
+      setTimeout(() => navigate('/login'), 1500);
+    } else {
+      toast.current.show({ severity: 'error', summary: 'Error', detail: data.message });
+    }
+  };
+
+  return (
+    <div className="login-container">
+      <Toast ref={toast} />
+      <CustomCard className="login-card">
+        <div className="login-header">
+          <h2>Crear Cuenta</h2>
+          <p>Solo emails @accenture.com</p>
+        </div>
+        <form onSubmit={handleSubmit} className="login-form">
+          <div className="form-group">
+            <label htmlFor="email">Email</label>
+            <InputField id="email" type="email" value={form.email} onChange={e => handleChange('email', e.target.value)} className="login-input" />
+          </div>
+          <div className="form-group">
+            <label htmlFor="password">Contraseña</label>
+            <InputField id="password" type="password" value={form.password} onChange={e => handleChange('password', e.target.value)} className="login-input" />
+          </div>
+          <CustomButton type="submit" label="Registrarme" className="login-button" />
+        </form>
+        <div className="login-footer">
+          <Link to="/login">Volver a iniciar sesión</Link>
+        </div>
+      </CustomCard>
+    </div>
+  );
+};
+
+export default Register;


### PR DESCRIPTION
## Summary
- add spring mail dependency
- send confirmation emails via `EmailService`
- manage pending signups in `RegistrationService`
- expose `/register` and `/confirm` endpoints
- create signup page in frontend and route to it
- link to new signup from login page
- store mail configuration sample

## Testing
- `mvn test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688aa2214b98832e8d7ab73c27518ce1